### PR TITLE
handle blank lines inside block

### DIFF
--- a/autoload/operator/surround.vim
+++ b/autoload/operator/surround.vim
@@ -233,7 +233,7 @@ function! s:surround_blocks(block_begin, block_end)
     let [_, last_line, end_col, _] = getpos("']")
     let is_extended = s:is_extended_blockwise_visual()
     for line in range(start_line, last_line)
-        if getline(line) ==# ''
+        if getline(line) =~# '^\s*$'
           continue
         endif
         " insert block to the one line in the block region
@@ -397,7 +397,7 @@ function! s:delete_surrounds_in_block()
     let is_extended = s:is_extended_blockwise_visual()
     try
         for line in range(start_line, last_line)
-            if getline(line) ==# ''
+            if getline(line) =~# '^\s*$'
               continue
             endif
             " yank to set '[ and ']

--- a/autoload/operator/surround.vim
+++ b/autoload/operator/surround.vim
@@ -233,6 +233,9 @@ function! s:surround_blocks(block_begin, block_end)
     let [_, last_line, end_col, _] = getpos("']")
     let is_extended = s:is_extended_blockwise_visual()
     for line in range(start_line, last_line)
+        if getline(line) ==# ''
+          continue
+        endif
         " insert block to the one line in the block region
         call s:normal(printf("%dgg%d|a%s\<Esc>%d|i%s\<Esc>",
                     \        line,
@@ -394,6 +397,9 @@ function! s:delete_surrounds_in_block()
     let is_extended = s:is_extended_blockwise_visual()
     try
         for line in range(start_line, last_line)
+            if getline(line) ==# ''
+              continue
+            endif
             " yank to set '[ and ']
             call s:normal(line.'gg')
             let end_of_line_col = last_col > col('$')-1 || is_extended ? col('$')-1 : last_col

--- a/t/corner_cases_spec.vim
+++ b/t/corner_cases_spec.vim
@@ -78,3 +78,54 @@ describe 'backslash in surrounds'
         Expect getline('.') ==# '(hoge)'
     end
 end
+
+describe 'blank line inside block'
+
+    before
+        map sa <Plug>(operator-surround-append)
+        map sr <Plug>(operator-surround-replace)
+        map sd <Plug>(operator-surround-delete)
+        new
+    end
+
+    after
+        close!
+        unmap sa
+        unmap sr
+        unmap sd
+    end
+
+    it 'should be ignored when adding surrounds'
+        1Line "hoge"
+        2Line ""
+        3Line "hoge"
+        execute 'normal' "gg0\<C-v>G$sa("
+
+        Expect getline(1) ==# "(hoge)"
+        Expect getline(2) ==# ""
+        Expect getline(3) ==# "(hoge)"
+    end
+
+    it 'should be ignored when replacing surrounds'
+        1Line "(hoge)"
+        2Line ""
+        3Line "(hoge)"
+        execute 'normal' "gg0\<C-v>G$sr'"
+
+        Expect getline(1) ==# "'hoge'"
+        Expect getline(2) ==# ""
+        Expect getline(3) ==# "'hoge'"
+    end
+
+    it 'should be ignored when deleting surrounds'
+        1Line "'hoge'"
+        2Line ""
+        3Line "'hoge'"
+        execute 'normal' "gg0\<C-v>G$sd'"
+
+        Expect getline(1) ==# "hoge"
+        Expect getline(2) ==# ""
+        Expect getline(3) ==# "hoge"
+    end
+
+end

--- a/t/corner_cases_spec.vim
+++ b/t/corner_cases_spec.vim
@@ -79,7 +79,7 @@ describe 'backslash in surrounds'
     end
 end
 
-describe 'blank line inside block'
+describe 'blank lines inside block'
 
     before
         map sa <Plug>(operator-surround-append)
@@ -98,34 +98,40 @@ describe 'blank line inside block'
     it 'should be ignored when adding surrounds'
         1Line "hoge"
         2Line ""
-        3Line "hoge"
+        3Line " "
+        4Line "hoge"
         execute 'normal' "gg0\<C-v>G$sa("
 
         Expect getline(1) ==# "(hoge)"
         Expect getline(2) ==# ""
-        Expect getline(3) ==# "(hoge)"
+        Expect getline(3) ==# " "
+        Expect getline(4) ==# "(hoge)"
     end
 
     it 'should be ignored when replacing surrounds'
         1Line "(hoge)"
         2Line ""
-        3Line "(hoge)"
+        3Line " "
+        4Line "(hoge)"
         execute 'normal' "gg0\<C-v>G$sr'"
 
         Expect getline(1) ==# "'hoge'"
         Expect getline(2) ==# ""
-        Expect getline(3) ==# "'hoge'"
+        Expect getline(3) ==# " "
+        Expect getline(4) ==# "'hoge'"
     end
 
     it 'should be ignored when deleting surrounds'
         1Line "'hoge'"
         2Line ""
-        3Line "'hoge'"
+        3Line " "
+        4Line "'hoge'"
         execute 'normal' "gg0\<C-v>G$sd'"
 
         Expect getline(1) ==# "hoge"
         Expect getline(2) ==# ""
-        Expect getline(3) ==# "hoge"
+        Expect getline(3) ==# " "
+        Expect getline(4) ==# "hoge"
     end
 
 end


### PR DESCRIPTION
When surrounding blocks with blank lines, blank lines are also surrounded.
So the following text:
```
test

test
test
```
becomes:
```
'test'
''
'test'
'test'
```
That behavior is undesirable in my opinion. I hope you'll consider including this pr.
