### PR TITLE
Don't consider ignore_space when deleting

### DIFF
--- a/autoload/operator/surround.vim
+++ b/autoload/operator/surround.vim
@@ -329,11 +329,7 @@ function! s:get_surround_in(region) abort
 endfunction
 
 function! s:get_same_str_surround(region) abort
-    if g:operator#surround#ignore_space
-        let region = matchstr(a:region, '^[[:space:]\n]*\zs.*\ze[[:space:]\n]*$')
-    else
-        let region = matchstr(a:region, '^\n*\zs.*\ze\n*$')
-    endif
+    let region = matchstr(a:region, '^[[:space:]\n]*\zs.*\ze[[:space:]\n]*$')
 
     let len = strlen(region)
 
@@ -374,9 +370,7 @@ function! s:delete_surround(visual) abort
         call s:normal('`['.a:visual.'`]"_d')
 
         " remove the former block and latter block
-        let space_skipper = g:operator#surround#ignore_space
-                    \ ? '\[[:space:]\n]\*'
-                    \ : '\n\*'
+        let space_skipper = '\[[:space:]\n]\*'
 
         let after = substitute(region, '^\V'. space_skipper . '\zs' . escape(block[0], '\') , '', '')
         let after = substitute(after, '\V' . escape(block[1], '\') . '\ze' . space_skipper . '\$', '', '')


### PR DESCRIPTION
According to the doc, `g:operator#surround#ignore_space` affects `<Plug>(operator-surround-append)` and `<Plug>(operator-surround-replace)`, not `<Plug>(operator-surround-delete)`.

Currently, `sda'` doesn't work with the example below when `g:operator#surround#ignore_space = 0` .
(Assume that `map sd <Plug>(operator-surround-delete)` and `_` is the cursor position.)

```
This is an 'example' text.
             _
```